### PR TITLE
Change %zu to %Iu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,33 @@ on:
 
 name: build
 jobs:
+  bof-lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: NoZuFormatter
+        run: |
+          cpp_files=$(find . -type f -wholename "*-BOF/*.cpp")
+          found=0
+          for file in $cpp_files; 
+          do
+              if grep -Hn "%zu" "$file"; 
+              then
+                  found=1
+              fi
+          done
+
+          if [ $found -eq 1 ]; 
+          then
+              echo "Found %zu in file. Beacon does not support this, change it to %Iu"
+              exit 1
+          else
+              exit 0
+          fi
   build:
     runs-on: windows-2022
+    needs: bof-lint
     steps:
       - uses: ilammy/msvc-dev-cmd@v1
       - name: Checkout

--- a/CredentialKatz-BOF/CredentialKatz/Memory.cpp
+++ b/CredentialKatz-BOF/CredentialKatz/Memory.cpp
@@ -188,10 +188,10 @@ extern "C" {
 #ifdef _DEBUG
         BeaconPrintf(CALLBACK_OUTPUT, "Address of beginNode: 0x%p\n", (void*)credentialMap.beginNode);
         BeaconPrintf(CALLBACK_OUTPUT, "Address of firstNode: 0x%p\n", (void*)credentialMap.firstNode);
-        BeaconPrintf(CALLBACK_OUTPUT, "Size of the credential map: %zu\n", credentialMap.size);
+        BeaconPrintf(CALLBACK_OUTPUT, "Size of the credential map: %Iu\n", credentialMap.size);
 #endif // _DEBUG
 
-        BeaconPrintf(CALLBACK_OUTPUT, "Number of available credentials: %zu\n\n", credentialMap.size);
+        BeaconPrintf(CALLBACK_OUTPUT, "Number of available credentials: %Iu\n\n", credentialMap.size);
 
         if (credentialMap.firstNode == 0) //CookieMap was empty
         {


### PR DESCRIPTION
Change the `%zu` format (which is not implemented in Beacon's MSVC runtime) to `%Iu`.

In addition, this PR adds a new job to the current build workflow to alert on any `%zu`  in the BOF source code files.